### PR TITLE
Fixed error 'The engine node is incompatible with this module' when trying to install deps with yarn'

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Mazzarolo Matteo",
   "license": "Apache-2.0",
   "engines": {
-    "node": "8.0.0"
+    "node": "^8.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This entry in package.json was too strict, since it prevented yarn or npm to install dependencies if the current version of Node wasn't exactly 8.0.0 (e.g., I have 8.5.0):
```json
  "engines": {
    "node": "8.0.0"
  }
```

I would receive an error like the following:
```bash
$ yarn
yarn install v1.0.2
[1/5] Validating package.json...
error numvalidate-app@1.0.0: The engine "node" is incompatible with this module. Expected version "8.0.0".
error Found incompatible module
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```

This should open the path to future contribution from people that don't use nvm and have Node's version >= 8.0.0 (so it doesn't break the intended behaviour)