### PR TITLE
Added basic unit tests for server/

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -44,10 +44,16 @@
               "REACT_APP_RATE_LIMIT_FOR_PRO_USER_REQUESTS",
               "REACT_APP_EMAIL_ADDRESS",
               "REACT_APP_GOOGLE_ANALYTICS_TRACKING_ID",
-              "REACT_APP_GOOGLE_SITE_VERIFICATION",
+              "REACT_APP_GOOGLE_SITE_VERIFICATION"
             ]
           }
         ]
+      ]
+    },
+    "test": {
+      "presets": [
+        ["env", { "modules": "commonjs" }],
+        "next/babel"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -108,5 +108,21 @@
     "print-width": 100,
     "trailing-comma": "es5",
     "single-quote": true
+  },
+  "jest": {
+    "verbose": true,
+    "transform": {
+      "^.+\\.js$": "babel-jest"
+    },
+    "globals": {
+      "NODE_ENV": "test"
+    },
+    "moduleFileExtensions": [
+      "js",
+      "jsx"
+    ],
+    "moduleDirectories": [
+      "node_modules"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Mazzarolo Matteo",
   "license": "Apache-2.0",
   "engines": {
-    "node": "8.0.0"
+    "node": "^8.0.0"
   },
   "repository": {
     "type": "git",

--- a/server/__tests__/utils.js
+++ b/server/__tests__/utils.js
@@ -1,0 +1,68 @@
+import {
+  toInt,
+  promisify,
+  getObjectKey,
+  generateApiToken,
+  isApiTokenValid,
+} from '../utils/common';
+
+describe('toInt', () => {
+  it('should parse a string to an integer', () => {
+    expect(toInt(5)).toBe(5);
+    expect(toInt('6')).toBe(6);
+    expect(toInt(null, 7)).toBe(7);
+  });
+});
+
+describe('promisify', () => {
+  const cb = (err, info) => {
+
+  }
+
+  const cbTest = (cb) => {
+    cb(null, 5);
+  }
+
+  it('should convert a function with a callback to a promise', async () => {
+    const promisifiedCbTest = promisify(cbTest);
+    const result = await promisifiedCbTest;
+    expect(result).toBe(5);
+  });
+});
+
+describe('getObjectKey', () => {
+  const obj = {
+    asd: true,
+    'a123': true,
+    'A123': true,
+  };
+
+  it(`should return the first key of the object that matches the given key without
+  considering object's property's case`, () => {
+    expect(getObjectKey(obj, 'asd')).toBe('asd');
+    expect(getObjectKey(obj, 'a123')).toBe('a123');
+    expect(getObjectKey(obj, 'qwerty')).toBe(undefined);
+  });
+});
+
+describe('generateApiToken', () => {
+  it('should generate an API token of 32 characters', () => {
+    const a = generateApiToken();
+    const b = generateApiToken();
+    expect(typeof a).toBe('string');
+    expect(typeof b).toBe('string');
+    expect(a.length).toBe(32);
+    expect(b.length).toBe(32);
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('isApiTokenValid', () => {
+  it('should check if the token provided is valid', () => {
+    expect(isApiTokenValid(generateApiToken())).toBe(true);
+    expect(isApiTokenValid('abc')).toBe(false);
+    expect(isApiTokenValid(123)).toBe(false);
+    expect(isApiTokenValid(NaN)).toBe(false);
+    expect(isApiTokenValid('abcdefghijklmnopqrstuvwxyz012345')).toBe(false);
+  });
+});


### PR DESCRIPTION
Besides having added the first unit tests, I've also configured `.babelrc` to correctly handle tests, since I was having [this issue](https://github.com/zeit/next.js/issues/2499).